### PR TITLE
Quote 3.0 so that 3.0.x versions are explicitly tested.  Add 3.1 as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: [2.7, 3.0]
+        ruby: [2.7, '3.0', 3.1]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
An unquoted 3.0 in a YAML file is treated as a 3 - the precision is lost.  So use of an unquoted 3.0 loads the latest Ruby 3 version - at this time 3.1.0.

This minor change to the CI configuration ensures:

1. The latest 3.0.x is tested
2. The latest 3.1.x is tested